### PR TITLE
Project 6: event-driven OpenCode PR review

### DIFF
--- a/.github/workflows/project-06-opencode-review.yml
+++ b/.github/workflows/project-06-opencode-review.yml
@@ -1,0 +1,37 @@
+name: project-06-opencode-review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out pull request
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Review pull request with OpenCode
+        uses: anomalyco/opencode/github@latest
+        env:
+          OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          model: opencode/claude-opus-4-5
+          use_github_token: true
+          prompt: |
+            Review this pull request as a read-only code reviewer.
+            Look for correctness bugs, especially off-by-one errors and
+            regressions. Run the relevant tests when possible.
+            If you find a real issue, leave a clear pull-request review
+            comment naming the file, behavior, and a minimal fix.
+            Do not modify files, commit, or push changes.

--- a/.github/workflows/project-06-opencode-review.yml
+++ b/.github/workflows/project-06-opencode-review.yml
@@ -26,7 +26,7 @@ jobs:
           OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          model: opencode/claude-opus-4-5
+          model: opencode/big-pickle
           use_github_token: true
           prompt: |
             Review this pull request as a read-only code reviewer.

--- a/loop-engineering/projects/06-doorbell-loop/README.md
+++ b/loop-engineering/projects/06-doorbell-loop/README.md
@@ -1,0 +1,40 @@
+# Project 6: The Doorbell Loop
+
+Project 6 connects the engineering agent to a GitHub pull-request event. A PR
+opening, update, reopen, or move out of draft automatically starts an OpenCode
+review. No prompt is typed after the event.
+
+## Real GitHub setup
+
+This project uses the official OpenCode GitHub Action shape. In a throwaway
+repository with a GitHub remote, run:
+
+```bash
+opencode github install
+```
+
+Accept the GitHub App installation and workflow setup, then ensure the selected
+provider key exists as an Actions secret. The checked-in
+the root `.github/workflows/project-06-opencode-review.yml` is the reproducible workflow: it uses
+the `pull_request` event, runs on `opened`, `synchronize`, `reopened`, and
+`ready_for_review`, and asks OpenCode to review without editing the PR.
+
+To perform the exercise, create a branch, run `bash scripts/plant-bug.sh`,
+commit it, and open a PR. The event should cause an unsolicited review that
+flags the off-by-one behavior in `src/range.js`. Push the corrected file to the
+same PR; the `synchronize` event should fire the loop again.
+
+## Local verification
+
+The local verifier proves the root workflow contract without claiming that a local
+shell is GitHub Actions. It checks the event, action, permissions, read-only
+prompt, passing base tests, lint, and that the planted bug makes the tests fail:
+
+```bash
+npm run verify
+```
+
+The live GitHub acceptance criterion remains: a PR review appears without a
+manual `/opencode` comment, and the review identifies the planted bug. GitHub
+credentials, an installed OpenCode App, and an API-key secret are required for
+that external check.

--- a/loop-engineering/projects/06-doorbell-loop/package.json
+++ b/loop-engineering/projects/06-doorbell-loop/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "project-06-doorbell-loop",
+  "private": true,
+  "scripts": {
+    "test": "node --test",
+    "lint": "node scripts/lint.js",
+    "verify": "bash scripts/verify-workflow.sh"
+  }
+}

--- a/loop-engineering/projects/06-doorbell-loop/scripts/lint.js
+++ b/loop-engineering/projects/06-doorbell-loop/scripts/lint.js
@@ -1,0 +1,10 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+for (const relative of ["src/range.js", "test/range.test.js"]) {
+  const file = path.join(__dirname, "..", relative);
+  const source = fs.readFileSync(file, "utf8");
+  new Function(source.replace(/module\.exports\s*=.*$/m, ""));
+}
+
+console.log("lint passed");

--- a/loop-engineering/projects/06-doorbell-loop/scripts/plant-bug.sh
+++ b/loop-engineering/projects/06-doorbell-loop/scripts/plant-bug.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+project_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+python3 - "$project_dir/src/range.js" <<'PY'
+from pathlib import Path
+import sys
+
+file = Path(sys.argv[1])
+text = file.read_text()
+fixed = "return items.slice(0, count);"
+buggy = "return items.slice(0, count + 1);"
+if fixed not in text:
+    raise SystemExit("fixed implementation was not found")
+file.write_text(text.replace(fixed, buggy, 1))
+PY
+echo "planted off-by-one bug in src/range.js"

--- a/loop-engineering/projects/06-doorbell-loop/scripts/verify-workflow.sh
+++ b/loop-engineering/projects/06-doorbell-loop/scripts/verify-workflow.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+project_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+repo_root=$(cd "$project_dir/../../.." && pwd)
+workflow="$repo_root/.github/workflows/project-06-opencode-review.yml"
+
+[[ -f "$workflow" ]] || { echo "workflow is missing" >&2; exit 1; }
+grep -Fq 'pull_request:' "$workflow"
+grep -Fq 'types: [opened, synchronize, reopened, ready_for_review]' "$workflow"
+grep -Fq 'anomalyco/opencode/github@latest' "$workflow"
+grep -Fq 'OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}' "$workflow"
+grep -Fq 'use_github_token: true' "$workflow"
+grep -Fq 'pull-requests: write' "$workflow"
+grep -Fq 'Do not modify files, commit, or push changes.' "$workflow"
+
+(cd "$project_dir" && npm test >/tmp/project-06-test.txt)
+(cd "$project_dir" && npm run lint >/tmp/project-06-lint.txt)
+
+cp "$project_dir/src/range.js" "$project_dir/src/range.js.verify-backup"
+trap 'mv "$project_dir/src/range.js.verify-backup" "$project_dir/src/range.js"' EXIT
+bash "$project_dir/scripts/plant-bug.sh"
+if (cd "$project_dir" && npm test >/tmp/project-06-planted-test.txt 2>&1); then
+  echo "planted bug was not detected" >&2
+  exit 1
+fi
+
+echo "Project 6 local contract passed: workflow trigger, connector, permissions, review prompt, base tests, lint, and planted-bug detection are valid."

--- a/loop-engineering/projects/06-doorbell-loop/src/range.js
+++ b/loop-engineering/projects/06-doorbell-loop/src/range.js
@@ -1,0 +1,8 @@
+function firstN(items, count) {
+  if (!Number.isInteger(count) || count < 0) {
+    throw new TypeError("count must be a non-negative integer");
+  }
+  return items.slice(0, count);
+}
+
+module.exports = { firstN };

--- a/loop-engineering/projects/06-doorbell-loop/src/range.js
+++ b/loop-engineering/projects/06-doorbell-loop/src/range.js
@@ -2,7 +2,7 @@ function firstN(items, count) {
   if (!Number.isInteger(count) || count < 0) {
     throw new TypeError("count must be a non-negative integer");
   }
-  return items.slice(0, count + 1);
+  return items.slice(0, count);
 }
 
 module.exports = { firstN };

--- a/loop-engineering/projects/06-doorbell-loop/src/range.js
+++ b/loop-engineering/projects/06-doorbell-loop/src/range.js
@@ -2,7 +2,7 @@ function firstN(items, count) {
   if (!Number.isInteger(count) || count < 0) {
     throw new TypeError("count must be a non-negative integer");
   }
-  return items.slice(0, count);
+  return items.slice(0, count + 1);
 }
 
 module.exports = { firstN };

--- a/loop-engineering/projects/06-doorbell-loop/test/range.test.js
+++ b/loop-engineering/projects/06-doorbell-loop/test/range.test.js
@@ -1,0 +1,11 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { firstN } = require("../src/range");
+
+test("returns exactly the requested number of items", () => {
+  assert.deepEqual(firstN(["a", "b", "c", "d"], 3), ["a", "b", "c"]);
+});
+
+test("allows zero", () => {
+  assert.deepEqual(firstN(["a"], 0), []);
+});


### PR DESCRIPTION
## Project 6 acceptance PR

This pull request exercises the event-driven OpenCode reviewer.

It contains an intentional off-by-one defect in `loop-engineering/projects/06-doorbell-loop/src/range.js`: `firstN(items, count)` returns one extra item.

The root `.github/workflows/project-06-opencode-review.yml` should review this pull request automatically on the `opened` event, without a manual `/opencode` prompt. The workflow must identify the defect and leave a review comment.

Pushing the correction later will exercise the `synchronize` event.