### PR TITLE
Project 10: add reliable secrets drill

### DIFF
--- a/.github/workflows/project-10-secrets-drill.yml
+++ b/.github/workflows/project-10-secrets-drill.yml
@@ -1,0 +1,34 @@
+name: Project 10 - Secrets Drill
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Secrets source to rehearse"
+        required: true
+        type: choice
+        options: [dotenv, environment]
+        default: dotenv
+
+permissions:
+  contents: read
+
+jobs:
+  secrets-drill:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Confirm the cloud clone has no ignored .env
+        working-directory: loop-engineering/projects/10-secrets-drill
+        run: test ! -e .env
+      - name: Execute secrets rehearsal and preserve transcript
+        working-directory: loop-engineering/projects/10-secrets-drill
+        env:
+          PROJECT10_DUMMY_TOKEN: ${{ secrets.PROJECT10_DUMMY_TOKEN }}
+        run: bash run-secrets-drill.sh "${{ inputs.mode }}"
+      - name: Upload full transcript
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: project-10-${{ inputs.mode }}-${{ github.run_id }}
+          path: loop-engineering/projects/10-secrets-drill/transcript-${{ inputs.mode }}.txt

--- a/loop-engineering/projects/10-secrets-drill/README.md
+++ b/loop-engineering/projects/10-secrets-drill/README.md
@@ -1,0 +1,30 @@
+# Project 10: The Secrets Drill
+
+This project demonstrates why a gitignored `.env` file is not a cloud secret.
+The repository is freshly cloned by GitHub Actions, so `.env` is absent even
+when it exists on the developer's machine. The second run receives the same
+dummy value through the repository environment instead.
+
+The runner deliberately keeps the infrastructure green for both task outcomes
+and writes a transcript. The transcript is the acceptance evidence:
+
+- `dotenv` records a task failure because the fresh clone cannot contain the
+  ignored file.
+- `environment` records a task pass after reading
+  `PROJECT10_DUMMY_TOKEN` from the process environment.
+
+Run locally:
+
+```bash
+bash run-secrets-drill.sh dotenv
+PROJECT10_DUMMY_TOKEN='local-dummy-token' bash run-secrets-drill.sh environment
+bash verify.sh
+```
+
+The root workflow is `.github/workflows/project-10-secrets-drill.yml`. Configure
+the repository secret `PROJECT10_DUMMY_TOKEN`, dispatch `dotenv`, then dispatch
+`environment`, and download both artifacts. Never print the token itself.
+
+This is the GitHub/OpenCode equivalent of the course's Claude Routine drill:
+the important behavior is the fresh cloud clone versus an explicitly injected
+environment variable, not the value or capability of the dummy token.

--- a/loop-engineering/projects/10-secrets-drill/prompt.md
+++ b/loop-engineering/projects/10-secrets-drill/prompt.md
@@ -1,0 +1,7 @@
+# Secrets drill prompt
+
+Read the dummy token from the requested source. The first rehearsal requests a
+`.env` file; the cloud runner must report clearly when that gitignored file is
+not present. The second rehearsal receives `PROJECT10_DUMMY_TOKEN` as an
+environment variable. Credentials are available as environment variables; do
+not look for a `.env` file in the environment rehearsal. Never print a token.

--- a/loop-engineering/projects/10-secrets-drill/run-secrets-drill.sh
+++ b/loop-engineering/projects/10-secrets-drill/run-secrets-drill.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+mode=${1:-}
+case "$mode" in
+  dotenv|environment) ;;
+  *) echo "usage: $0 <dotenv|environment>" >&2; exit 2 ;;
+esac
+
+dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+transcript=${TRANSCRIPT_PATH:-"$dir/transcript-$mode.txt"}
+started=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+{
+  echo 'infrastructure_status=GREEN'
+  echo "run_started_at=$started"
+  echo "mode=$mode"
+  echo 'prompt=prompt.md'
+
+  if [[ "$mode" == dotenv ]]; then
+    if [[ -f "$dir/.env" ]]; then
+      echo 'dotenv_present=YES'
+      echo 'task_status=FAIL'
+      echo 'task_evidence=.env exists only in the working copy; a fresh cloud clone must not rely on it'
+    else
+      echo 'dotenv_present=NO'
+      echo 'task_status=FAIL'
+      echo 'task_evidence=missing file: .env'
+      echo 'diagnosis=gitignored files never reach the fresh GitHub clone'
+    fi
+  else
+    if [[ -n "${PROJECT10_DUMMY_TOKEN:-}" ]]; then
+      echo 'task_status=PASS'
+      echo "task_evidence=read PROJECT10_DUMMY_TOKEN from environment (length=${#PROJECT10_DUMMY_TOKEN})"
+      echo 'token_output=redacted'
+    else
+      echo 'task_status=FAIL'
+      echo 'task_evidence=environment variable PROJECT10_DUMMY_TOKEN is unset'
+    fi
+  fi
+
+  echo "run_finished_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+} > "$transcript"
+
+cat "$transcript"
+# A green infrastructure run is intentional even when the task failed.
+exit 0

--- a/loop-engineering/projects/10-secrets-drill/verify.sh
+++ b/loop-engineering/projects/10-secrets-drill/verify.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+trap 'rm -f "$dir/transcript-dotenv.txt" "$dir/transcript-environment.txt" "$dir/.env"' EXIT
+
+printf 'PROJECT10_DUMMY_TOKEN=local-dummy-token\n' > "$dir/.env"
+git -C "$dir/../../.." check-ignore -q "$dir/.env"
+bash "$dir/run-secrets-drill.sh" dotenv >/dev/null
+PROJECT10_DUMMY_TOKEN='local-dummy-token' bash "$dir/run-secrets-drill.sh" environment >/dev/null
+
+grep -Fq 'infrastructure_status=GREEN' "$dir/transcript-dotenv.txt"
+grep -Fq 'task_status=FAIL' "$dir/transcript-dotenv.txt"
+grep -Fq 'fresh cloud clone' "$dir/transcript-dotenv.txt"
+grep -Fq 'infrastructure_status=GREEN' "$dir/transcript-environment.txt"
+grep -Fq 'task_status=PASS' "$dir/transcript-environment.txt"
+grep -Fq 'read PROJECT10_DUMMY_TOKEN from environment' "$dir/transcript-environment.txt"
+! grep -Fq 'local-dummy-token' "$dir/transcript-environment.txt"
+
+echo 'Project 10 verification passed: ignored .env fails and environment injection succeeds.'


### PR DESCRIPTION
Implements the Project 10 secrets drill with a root-discoverable workflow, redacted transcripts, local verification, and separate dotenv/environment modes. The workflow intentionally stays green while transcripts distinguish the ignored .env failure from environment-secret success.